### PR TITLE
fix: Support zero-width spans for position markers

### DIFF
--- a/functions/models.py
+++ b/functions/models.py
@@ -101,7 +101,7 @@ class SpanModel(OpenPechaModel):
 
     @model_validator(mode="after")
     def validate_span_range(self):
-        if self.start >= self.end:
+        if self.start > self.end:
             raise ValueError("'start' must be less than 'end'")
         return self
 


### PR DESCRIPTION
Allow spans where start == end to represent endline markers or insertion points in segmentation. Changed validation from start >= end (invalid) to start > end (invalid) to permit zero-width position markers in segment annotations.