### PR TITLE
Add health check endpoint and update instance retrieval logic

### DIFF
--- a/functions/api/instances.py
+++ b/functions/api/instances.py
@@ -93,6 +93,7 @@ def get_instance(manifestation_id: str):
 
     logger.info("Fetching with manifestation ID: %s", manifestation_id)
 
+    content_param = request.args.get("content", "false").lower() == "true"
     annotation_param = request.args.get("annotation", "false").lower() == "true"
     logger.info("Annotation parameter %s", annotation_param)
 
@@ -101,7 +102,9 @@ def get_instance(manifestation_id: str):
     manifestation, expression_id = Neo4JDatabase().get_manifestation(manifestation_id = manifestation_id)
 
     logger.info("Retrieving base text from storage")
-    base_text = retrieve_base_text(expression_id = expression_id, manifestation_id = manifestation_id)
+    base_text = None
+    if content_param:
+        base_text = retrieve_base_text(expression_id = expression_id, manifestation_id = manifestation_id)
 
     metadata = {
         "id": manifestation.id,
@@ -135,6 +138,10 @@ def get_instance(manifestation_id: str):
         "metadata": metadata,
         "annotations": annotations,
     }
+    if not content_param:
+        json.pop("content")
+    if not annotation_param:
+        json.pop("annotations")
 
     return jsonify(json), 200
 

--- a/functions/api/schema/openapi.yaml
+++ b/functions/api/schema/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.3
 info:
   title: OpenPecha API v2
   version: '2.1.0'
@@ -31,6 +31,13 @@ paths:
             type: boolean
             default: false
           description: Whether to include annotations (alignment annotations are excluded)
+        - name: content
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: Whether to include content (base text)
       responses:
         "200":
           description: Instance retrieved successfully
@@ -79,8 +86,44 @@ paths:
                           type: string
                           enum: [segmentation, version]
               examples:
-                success:
-                  summary: Instance with metadata and optional annotations
+                with_annotations_no_content:
+                  summary: Instance with metadata, annotation without content
+                  value:
+                    metadata:
+                      id: "I12345678"
+                      type: "critical"
+                      copyright: "public"
+                      bdrc: "W123456"
+                      wiki: "Q123456"
+                      colophon: "colophon text"
+                      incipit_title:
+                        en: "English incipit title"
+                        bo: "Tibetan incipit title"
+                      alt_incipit_titles:
+                        - en: "Alt title 1"
+                        - bo: "Alt title 2"
+                    annotations:
+                      - annotation_id: "A12345678"
+                        type: "segmentation"
+                with_content_no_annotations:
+                  summary: Instance with metadata, content without annotations
+                  value:
+                    content: "This is the base text content"
+                    metadata:
+                      id: "I12345678"
+                      type: "critical"
+                      copyright: "public"
+                      bdrc: "W123456"
+                      wiki: "Q123456"
+                      colophon: "colophon text"
+                      incipit_title:
+                        en: "English incipit title"
+                        bo: "Tibetan incipit title"
+                      alt_incipit_titles:
+                        - en: "Alt title 1"
+                        - bo: "Alt title 2"
+                with_content_and_annotations:
+                  summary: Instance with metadata, annotations and content
                   value:
                     content: "This is the base text content"
                     metadata:
@@ -243,7 +286,10 @@ paths:
                             role: "translator"
                       annotation: "A98765434"
                       relationship: "translation"
-                  error: "No segments found containing span [0, 100) in instance 'I12345678'"
+        "400":
+          $ref: '#/components/responses/InvalidRequest'
+        "404":
+          $ref: '#/components/responses/NotFound'
         "500":
           $ref: '#/components/responses/ServerError'
 

--- a/functions/main.py
+++ b/functions/main.py
@@ -49,6 +49,11 @@ def create_app(testing=False):
     app.register_blueprint(annotations_bp, url_prefix="/v2/annotations")
     app.register_blueprint(categories_bp, url_prefix="/v2/categories")
 
+    @app.route("/__/health")
+    def health_check():
+        """Health check endpoint for Firebase Functions."""
+        return jsonify({"status": "healthy"}), 200
+
     @app.after_request
     def add_no_cache_headers(response):
         """Add no-cache headers to all responses."""


### PR DESCRIPTION
- Introduced a new health check endpoint at "/__/health" to monitor service status.
- Modified the get_instance function to conditionally retrieve base text based on the 'content' query parameter.
- Updated response structure to exclude 'content' and 'annotations' fields based on query parameters.
- Enhanced OpenAPI schema to document the new 'content' query parameter and added examples for various response scenarios.