### PR TITLE
feat: implement search segments API with segmentation mapping

### DIFF
--- a/functions/api/schema/openapi.yaml
+++ b/functions/api/schema/openapi.yaml
@@ -3219,6 +3219,140 @@ paths:
         "500":
           $ref: '#/components/responses/ServerError'
 
+  /v2/segments/search:
+    post:
+      summary: Search segments with segmentation mapping
+      description: >-
+        Search segments by forwarding request to external search API and enriching results
+        with overlapping segmentation annotation segment IDs. For each search result (which contains
+        a search_segmentation segment ID), finds overlapping segments from segmentation annotations
+        and adds them as segmentation_ids.
+      tags:
+        - Segments
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - query
+              properties:
+                query:
+                  type: string
+                  minLength: 1
+                  description: The search query text
+                search_type:
+                  type: string
+                  enum: [hybrid, bm25, semantic, exact]
+                  default: hybrid
+                  description: Type of search (hybrid, bm25, semantic, or exact)
+                limit:
+                  type: integer
+                  minimum: 1
+                  maximum: 100
+                  default: 10
+                  description: Maximum number of results to return
+                filter:
+                  type: object
+                  properties:
+                    title:
+                      type: string
+                      description: Filter results by title
+                  description: Optional filters to apply
+            examples:
+              hybrid_search:
+                summary: Hybrid search request
+                value:
+                  query: "བོད་ཀྱི་རིག་གནས།"
+                  search_type: "hybrid"
+                  limit: 10
+                  filter:
+                    title: "Kangyur"
+              semantic_search:
+                summary: Semantic search request
+                value:
+                  query: "Buddhist philosophy"
+                  search_type: "semantic"
+                  limit: 20
+      responses:
+        "200":
+          description: Search completed successfully with enriched results
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - query
+                  - search_type
+                  - results
+                  - count
+                properties:
+                  query:
+                    type: string
+                    description: The search query that was used
+                  search_type:
+                    type: string
+                    description: The search type that was used
+                  results:
+                    type: array
+                    description: List of search results with segmentation IDs
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - distance
+                        - entity
+                        - segmentation_ids
+                      properties:
+                        id:
+                          type: string
+                          description: Search segmentation segment ID
+                        distance:
+                          type: number
+                          description: Search distance/score
+                        entity:
+                          type: object
+                          additionalProperties: true
+                          description: Additional entity data from search
+                        segmentation_ids:
+                          type: array
+                          items:
+                            type: string
+                          description: List of overlapping segmentation annotation segment IDs
+                  count:
+                    type: integer
+                    description: Number of results returned
+              examples:
+                success:
+                  summary: Search results with segmentation IDs
+                  value:
+                    query: "བོད་ཀྱི་རིག་གནས།"
+                    search_type: "hybrid"
+                    results:
+                      - id: "SEG_SEARCH_001"
+                        distance: 0.85
+                        entity:
+                          text: "Sample text content"
+                        segmentation_ids:
+                          - "SEG_001"
+                          - "SEG_002"
+                          - "SEG_003"
+                      - id: "SEG_SEARCH_002"
+                        distance: 0.78
+                        entity:
+                          text: "Another text content"
+                        segmentation_ids:
+                          - "SEG_004"
+                          - "SEG_005"
+                    count: 2
+        "400":
+          $ref: '#/components/responses/InvalidRequest'
+        "422":
+          $ref: '#/components/responses/ValidationError'
+        "500":
+          $ref: '#/components/responses/ServerError'
+
   /v2/relations/expressions/{expression_id}:
     get:
       summary: Get relations for an expression

--- a/functions/api/segments.py
+++ b/functions/api/segments.py
@@ -1,12 +1,18 @@
 import logging
 
-from flask import Blueprint, Response, jsonify
+import requests
+from exceptions import InvalidRequest, DataNotFound
+from flask import Blueprint, Response, jsonify, request
+from models import SearchRequestModel, SearchResponseModel, SearchResultModel
 from neo4j_database import Neo4JDatabase
 from pecha_handling import retrieve_pecha
 
 segments_bp = Blueprint("segments", __name__)
 
 logger = logging.getLogger(__name__)
+
+# Search API URL
+SEARCH_API_URL = "https://openpecha-search.onrender.com"
 
 
 @segments_bp.route("/<string:segment_id>/related", methods=["GET"], strict_slashes=False)
@@ -53,3 +59,102 @@ def get_segment_content(segment_id: str) -> tuple[Response, int]:
     base_text = next(iter(pecha.bases.values()))
 
     return jsonify({"content": base_text[segment.span[0] : segment.span[1]]}), 200
+
+
+@segments_bp.route("/search", methods=["POST"], strict_slashes=False)
+def search_segments() -> tuple[Response, int]:
+    """
+    Search segments by forwarding request to external search API and enriching results
+    with overlapping segmentation annotation segment IDs.
+    """
+    # Parse and validate request body
+    data = request.get_json(force=True, silent=True)
+    if not data:
+        raise InvalidRequest("Request body is required")
+    
+    search_request = SearchRequestModel.model_validate(data)
+    
+    # Forward request to external search API
+    try:
+        logger.info(f"Forwarding search request to {SEARCH_API_URL}/search")
+        response = requests.post(
+            f"{SEARCH_API_URL}/search",
+            json=search_request.model_dump(),
+            timeout=60
+        )
+        response.raise_for_status()
+        search_response_data = response.json()
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Error calling search API: {str(e)}")
+        raise InvalidRequest(f"Failed to call search API: {str(e)}")
+    
+    # Process results to add segmentation_ids
+    db = Neo4JDatabase()
+    enriched_results = []
+    
+    for result_item in search_response_data.get("results", []):
+        segment_id = result_item.get("id")
+        if not segment_id:
+            # If no ID, just add the result as-is without segmentation_ids
+            enriched_result = SearchResultModel(
+                id=result_item.get("id", ""),
+                distance=result_item.get("distance", 0.0),
+                entity=result_item.get("entity", {}),
+                segmentation_ids=[]
+            )
+            enriched_results.append(enriched_result)
+            continue
+        
+        try:
+            # Get segment info (span and manifestation_id)
+            segment, manifestation_id, _ = db.get_segment(segment_id)
+            
+            # Get overlapping segments from segmentation annotations
+            overlapping_segments = db._get_overlapping_segments(
+                manifestation_id=manifestation_id,
+                start=segment.span.start,
+                end=segment.span.end
+            )
+            
+            # Extract segment IDs
+            segmentation_ids = [seg["segment_id"] for seg in overlapping_segments]
+            
+            # Create enriched result
+            enriched_result = SearchResultModel(
+                id=result_item.get("id", ""),
+                distance=result_item.get("distance", 0.0),
+                entity=result_item.get("entity", {}),
+                segmentation_ids=segmentation_ids
+            )
+            enriched_results.append(enriched_result)
+            
+        except DataNotFound:
+            # If segment not found, add result without segmentation_ids
+            logger.warning(f"Segment {segment_id} not found, skipping segmentation mapping")
+            enriched_result = SearchResultModel(
+                id=result_item.get("id", ""),
+                distance=result_item.get("distance", 0.0),
+                entity=result_item.get("entity", {}),
+                segmentation_ids=[]
+            )
+            enriched_results.append(enriched_result)
+        except Exception as e:
+            # Log error but continue processing other results
+            logger.error(f"Error processing segment {segment_id}: {str(e)}")
+            enriched_result = SearchResultModel(
+                id=result_item.get("id", ""),
+                distance=result_item.get("distance", 0.0),
+                entity=result_item.get("entity", {}),
+                segmentation_ids=[]
+            )
+            enriched_results.append(enriched_result)
+    
+    # Create enriched response
+    enriched_response = SearchResponseModel(
+        query=search_response_data.get("query", search_request.query),
+        search_type=search_response_data.get("search_type", search_request.search_type),
+        results=enriched_results,
+        count=len(enriched_results)
+    )
+    
+    return jsonify(enriched_response.model_dump()), 200

--- a/functions/models.py
+++ b/functions/models.py
@@ -523,3 +523,24 @@ class EnumType(str, Enum):
 class EnumRequestModel(OpenPechaModel):
     type: EnumType
     value: dict[str, NonEmptyStr]
+
+class SearchFilterModel(OpenPechaModel):
+    title: str | None = None
+
+class SearchRequestModel(OpenPechaModel):
+    query: NonEmptyStr
+    search_type: str = "hybrid"
+    limit: int = Field(default=10, ge=1, le=100)
+    filter: SearchFilterModel | None = None
+
+class SearchResultModel(OpenPechaModel):
+    id: str
+    distance: float
+    entity: dict
+    segmentation_ids: list[str] = Field(default_factory=list)
+
+class SearchResponseModel(OpenPechaModel):
+    query: str
+    search_type: str
+    results: list[SearchResultModel]
+    count: int


### PR DESCRIPTION
- Added new models for search requests and responses, including filtering options.
- Implemented the `/search` endpoint to forward requests to an external search API and enrich results with segmentation IDs.
- Updated OpenAPI schema to document the new search functionality and its request/response structure.