### PR TITLE
feat: add batch endpoint for retrieving overlapping segments

### DIFF
--- a/functions/api/schema/openapi.yaml
+++ b/functions/api/schema/openapi.yaml
@@ -3410,6 +3410,85 @@ paths:
         "500":
           $ref: '#/components/responses/ServerError'
 
+  /v2/segments/batch-overlapping:
+    post:
+      summary: Get overlapping segments in batch
+      description: |
+        Get overlapping segments for multiple segment IDs in a single batch request.
+        Returns overlapping segments from the segmentation annotation of the same manifestation.
+      tags:
+        - Segments
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                segment_ids:
+                  type: array
+                  items:
+                    type: string
+                  description: List of segment IDs to get overlapping segments for
+                  example: ["SEG001", "SEG002", "SEG003"]
+              required:
+                - segment_ids
+      responses:
+        "200":
+          description: Overlapping segments retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    segment_id:
+                      type: string
+                      description: The input segment ID
+                    overlapping_segments:
+                      type: array
+                      items:
+                        type: string
+                      description: List of overlapping segment IDs
+              examples:
+                success:
+                  summary: Overlapping segments for multiple IDs
+                  value:
+                    - segment_id: "SEG001"
+                      overlapping_segments:
+                        - "SEG_OVERLAP_001"
+                        - "SEG_OVERLAP_002"
+                    - segment_id: "SEG002"
+                      overlapping_segments:
+                        - "SEG_OVERLAP_003"
+                    - segment_id: "SEG003"
+                      overlapping_segments: []
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+              examples:
+                missing_body:
+                  summary: Missing request body
+                  value:
+                    error: "Request body is required"
+                invalid_type:
+                  summary: Invalid segment_ids type
+                  value:
+                    error: "segment_ids must be a list"
+                empty_list:
+                  summary: Empty segment_ids
+                  value:
+                    error: "segment_ids cannot be empty"
+        "500":
+          $ref: '#/components/responses/ServerError'
+
   /v2/relations/expressions/{expression_id}:
     get:
       summary: Get relations for an expression

--- a/functions/neo4j_database.py
+++ b/functions/neo4j_database.py
@@ -1546,6 +1546,27 @@ class Neo4JDatabase:
                 for record in result
             ]
 
+    def _get_overlapping_segments_batch(self, segment_ids: list[str]) -> dict[str, list[dict]]:
+        """
+        Get overlapping segments for multiple segment IDs in a single batch query.
+        Returns a dict mapping segment_id to list of overlapping segments.
+        """
+        if not segment_ids:
+            return {}
+        
+        with self.get_session() as session:
+            result = session.execute_read(
+                lambda tx: tx.run(
+                    Queries.segments["get_overlapping_segments_batch"],
+                    segment_ids=segment_ids
+                ).data()
+            )
+            
+            # Convert to dict format
+            return {
+                record["input_segment_id"]: record["overlapping_segments"]
+                for record in result
+            }
 
     def _get_aligned_segments(self, alignment_1_id: str, start:int, end:int) -> list[dict]:
         with self.get_session() as session:

--- a/functions/neo4j_queries.py
+++ b/functions/neo4j_queries.py
@@ -760,6 +760,19 @@ RETURN s.id as segment_id,
        s.span_start as span_start,
        s.span_end as span_end
 ORDER BY s.span_start
+""",
+    "get_overlapping_segments_batch": """
+UNWIND $segment_ids AS input_segment_id
+MATCH (input_seg:Segment {id: input_segment_id})
+      -[:SEGMENTATION_OF]->(input_ann:Annotation)
+      -[:ANNOTATION_OF]->(m:Manifestation)
+MATCH (seg_ann:Annotation)-[:HAS_TYPE]->(:AnnotationType {name: 'segmentation'})
+MATCH (seg_ann)-[:ANNOTATION_OF]->(m)
+MATCH (seg:Segment)-[:SEGMENTATION_OF]->(seg_ann)
+WHERE seg.span_start < input_seg.span_end 
+  AND seg.span_end > input_seg.span_start
+RETURN input_segment_id, 
+       collect(seg.id) as overlapping_segments
 """
 }
 


### PR DESCRIPTION
- Introduced a new API endpoint `/v2/segments/batch-overlapping` to fetch overlapping segments for multiple segment IDs in a single request.
- Implemented the `_get_overlapping_segments_batch` method in the Neo4JDatabase class to handle batch queries.
- Updated OpenAPI schema to document the new endpoint, request body, and response structure.