### PR TITLE
feat: add get_work_ids_by_expression_ids method and related API endpo…

### DIFF
--- a/functions/api/instances.py
+++ b/functions/api/instances.py
@@ -24,6 +24,7 @@ from api.annotations import _alignment_annotation_mapping
 from exceptions import InvalidRequest
 from api.relation import _get_relation_for_an_expression
 from neo4j_database_validator import Neo4JDatabaseValidator
+from api.relation import _get_expression_relations
 
 instances_bp = Blueprint("instances", __name__)
 
@@ -400,6 +401,15 @@ def get_related_instances(manifestation_id: str) -> tuple[Response, int]:
         return jsonify({"error": str(e)}), 500
 
     return jsonify(related_instances), 200
+
+@instances_bp.route("<string:manifestation_id>/related-all", methods=["GET"], strict_slashes=False)
+def get_all_related_instances(manifestation_id: str) -> tuple[Response, int]:
+
+    expression_relations = _get_expression_relations(expression_id=manifestation_id)
+    
+    
+
+    return jsonify(expression_relations), 200
 
 
 @instances_bp.route("/<string:manifestation_id>/segment-content", methods=["POST"], strict_slashes=False)

--- a/functions/api/schema/openapi.yaml
+++ b/functions/api/schema/openapi.yaml
@@ -1944,6 +1944,69 @@ paths:
         "500":
           $ref: '#/components/responses/ServerError'
 
+  /v2/texts/{text_id}/related-by-work:
+    get:
+      summary: Get texts grouped by work ID
+      description: >-
+        Returns texts grouped by their work_id for all related texts.
+        This allows you to easily identify which texts belong to the same work.
+        
+        Takes a text ID directly and finds all related texts
+        (translations, commentaries, roots, etc.), then returns them grouped by work_id
+        with their relationship type.
+      tags:
+        - Texts
+      parameters:
+        - name: text_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The text ID
+      responses:
+        "200":
+          description: Texts grouped by work retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: object
+                  properties:
+                    relation:
+                      type: string
+                      nullable: true
+                      enum: [translation, commentary, root, sibling_root, sibling_commentary]
+                      description: The relation type for texts in this work group
+                    text_ids:
+                      type: array
+                      items:
+                        type: string
+                      description: List of text IDs in this work group
+                description: Dictionary with work_id as key and object containing relation type and text IDs as value
+                example:
+                  "W001":
+                    relation: "translation"
+                    text_ids: ["T001", "T002", "T004"]
+                  "W002":
+                    relation: "commentary"
+                    text_ids: ["T003"]
+                  "W003":
+                    relation: null
+                    text_ids: ["T005"]
+        "404":
+          description: Text not found or has no relations
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Text with ID T123 not found"
+        "500":
+          $ref: '#/components/responses/ServerError'
+
   /v2/persons:
     get:
       summary: Retrieve all persons

--- a/functions/api/texts.py
+++ b/functions/api/texts.py
@@ -14,6 +14,7 @@ from models import (
 from neo4j_database import Neo4JDatabase
 from storage import MockStorage
 from neo4j_database_validator import Neo4JDatabaseValidator
+from api.relation import _get_expression_relations
 
 texts_bp = Blueprint("texts", __name__)
 
@@ -186,3 +187,41 @@ def create_instance(expression_id: str) -> tuple[Response, int]:
         )
 
     return jsonify({"message": "Instance created successfully", "id": manifestation_id}), 201
+
+
+@texts_bp.route("/<string:expression_id>/related-by-work", methods=["GET"], strict_slashes=False)
+def get_related_by_work(expression_id: str) -> tuple[Response, int]:
+    """
+    Get work_id mapping for all related expressions.
+    
+    Returns a dictionary with work_id as key and list of expression_ids as values:
+    { "work_id_1": ["expr_id_1", "expr_id_2"], "work_id_2": ["expr_id_3"] }
+    """
+    logger.info("Getting work mapping for related expressions of expression ID: %s", expression_id)
+    
+    db = Neo4JDatabase()
+    
+    # Convert manifestation_id to expression_id
+    expression_relations = _get_expression_relations(expression_id=expression_id)
+    
+    # Extract all expression_ids (keys from the relations dictionary)
+    expression_ids = list(expression_relations.keys())
+    
+    # Get work_id mapping for all expressions (expression_id -> work_id)
+    work_mapping = db.get_work_ids_by_expression_ids(expression_ids)
+    
+    # Transform to work_id -> [expression_ids]
+    grouped_by_work = {}
+    for expr_id, work_id in work_mapping.items():
+        if expression_relations.get(expr_id) is None:
+            continue
+        if work_id not in grouped_by_work:
+            grouped_by_work[work_id] = {
+                "relation": None,
+                "expression_ids": []
+            }
+        if grouped_by_work[work_id].get("relation", None) is None and expression_relations.get(expr_id) is not None:
+            grouped_by_work[work_id]["relation"] = expression_relations.get(expr_id).lower()
+        grouped_by_work[work_id]["expression_ids"].append(expr_id)
+    
+    return jsonify(grouped_by_work), 200

--- a/functions/neo4j_database.py
+++ b/functions/neo4j_database.py
@@ -290,6 +290,28 @@ class Neo4JDatabase:
             )
             return {record["manifestation_id"]: record["expression_id"] for record in result}
 
+    def get_work_ids_by_expression_ids(self, expression_ids: list[str]) -> dict[str, str]:
+        """
+        Get work IDs for a list of expression IDs.
+        
+        Args:
+            expression_ids: List of expression IDs
+            
+        Returns:
+            Dictionary mapping expression_id to work_id
+        """
+        if not expression_ids:
+            return {}
+        
+        with self.__driver.session() as session:
+            result = session.execute_read(
+                lambda tx: list(tx.run(
+                    Queries.expressions["get_work_ids_by_expression_ids"],
+                    expression_ids=expression_ids
+                ))
+            )
+            return {record["expression_id"]: record["work_id"] for record in result}
+
     def get_manifestations_metadata_by_ids(self, manifestation_ids: list[str]) -> dict[str, dict]:
         """
         Get metadata for a list of manifestation IDs.

--- a/functions/neo4j_queries.py
+++ b/functions/neo4j_queries.py
@@ -289,6 +289,11 @@ MATCH (e1)-[:EXPRESSION_OF]->(w:Work)
 MATCH (w)<-[:EXPRESSION_OF]-(e:Expression)
 WHERE e.id <> e1.id
 RETURN {Queries.expression_fragment('e')} AS expression
+""",
+    "get_work_ids_by_expression_ids": """
+MATCH (e:Expression)-[:EXPRESSION_OF]->(w:Work)
+WHERE e.id IN $expression_ids
+RETURN e.id as expression_id, w.id as work_id
 """
 }
 


### PR DESCRIPTION
…ints

- Introduced `get_work_ids_by_expression_ids` method in the Neo4JDatabase class to retrieve work IDs for a list of expression IDs.
- Added new API endpoint `/v2/texts/{text_id}/related-by-work` to return texts grouped by work ID for related texts.
- Updated OpenAPI schema to document the new endpoint and its response structure.