### PR TITLE
feat: add title search functionality to texts API

### DIFF
--- a/functions/api/schema/openapi.yaml
+++ b/functions/api/schema/openapi.yaml
@@ -1944,6 +1944,52 @@ paths:
         "500":
           $ref: '#/components/responses/ServerError'
 
+  /v2/texts/title-search:
+    get:
+      summary: Search texts by title
+      description: Search for texts by matching title or alternative titles. Returns expressions that have matching titles along with their critical manifestations.
+      tags:
+        - Texts
+      parameters:
+        - name: title
+          in: query
+          required: true
+          schema:
+            type: string
+          description: The title search term to match (case-sensitive substring match)
+          example: "བསྟན་འགྱུར།"
+      responses:
+        "200":
+          description: Search completed successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    text_id:
+                      type: string
+                      description: The expression ID of the matched text
+                    title:
+                      type: string
+                      description: The matched title text
+                    instance_id:
+                      type: string
+                      description: The manifestation ID of the critical edition
+              examples:
+                success:
+                  summary: Title search results
+                  value:
+                    - text_id: "T12345678"
+                      title: "བསྟན་འགྱུར།"
+                      instance_id: "M12345678"
+                    - text_id: "T87654321"
+                      title: "བསྟན་འགྱུར་དཔེ་བསྡུར་མ།"
+                      instance_id: "M87654321"
+        "500":
+          $ref: '#/components/responses/ServerError'
+
   /v2/persons:
     get:
       summary: Retrieve all persons

--- a/functions/api/texts.py
+++ b/functions/api/texts.py
@@ -181,3 +181,10 @@ def create_instance(expression_id: str) -> tuple[Response, int]:
     )
 
     return jsonify({"message": "Instance created successfully", "id": manifestation_id}), 201
+
+@texts_bp.route("/title-search/", methods=["GET"], strict_slashes=False)
+def title_search() -> tuple[Response, int]:
+    db = Neo4JDatabase()
+    title = request.args.get("title")
+    response_data = db.title_search(title=title)
+    return jsonify(response_data), 200

--- a/functions/neo4j_database.py
+++ b/functions/neo4j_database.py
@@ -1732,3 +1732,21 @@ class Neo4JDatabase:
         return {
             "texts": expressions
         }
+    
+    def title_search(self, title: str) -> list[dict]:
+        with self.get_session() as session:
+            result = session.execute_read(
+                lambda tx: tx.run(
+                    Queries.expressions["title_search"],
+                    title=title
+                ).data()
+            )
+            result = [
+                {
+                    "text_id": record["expression_id"],
+                    "title": record["title"],
+                    "instance_id": record["manifestation_id"]
+                }
+                for record in result
+            ]
+            return result

--- a/functions/neo4j_queries.py
+++ b/functions/neo4j_queries.py
@@ -298,7 +298,15 @@ MATCH (e1)-[:EXPRESSION_OF]->(w:Work)
 MATCH (w)<-[:EXPRESSION_OF]-(e:Expression)
 WHERE e.id <> e1.id
 RETURN {Queries.expression_fragment('e')} AS expression
-"""
+""",
+    "title_search": f"""
+MATCH (lt:LocalizedText)<-[:HAS_LOCALIZATION]-(n:Nomen)
+MATCH (e:Expression)-[:HAS_TITLE]->(titleNomen:Nomen)
+WHERE lt.text CONTAINS $title
+  AND (n = titleNomen OR (n)-[:ALTERNATIVE_OF]->(titleNomen))
+MATCH (e)<-[:MANIFESTATION_OF]-(m:Manifestation)-[:HAS_TYPE]->(mt: ManifestationType {{name: 'critical'}})
+RETURN DISTINCT e.id as expression_id, lt.text as title, m.id as manifestation_id
+""",
 }
 
 Queries.persons = {


### PR DESCRIPTION
- Implemented a new endpoint `/v2/texts/title-search` to allow searching for texts by title or alternative titles.
- Added the `title_search` method in the Neo4JDatabase class to execute the corresponding query and return matching expressions with their critical manifestations.
- Updated OpenAPI schema to document the new endpoint, including request parameters and response structure.