### PR TITLE
feat: implement asynchronous search segmenter API trigger

### DIFF
--- a/functions/api/instances.py
+++ b/functions/api/instances.py
@@ -1,4 +1,6 @@
 import logging
+import threading
+import requests
 
 from flask import Blueprint, Response, jsonify, request
 from identifier import generate_id
@@ -29,6 +31,28 @@ from api.relation import _get_expression_relations
 instances_bp = Blueprint("instances", __name__)
 
 logger = logging.getLogger(__name__)
+
+
+def _trigger_search_segmenter(manifestation_id: str) -> None:
+    """
+    Triggers the search segmenter API asynchronously (fire-and-forget).
+    
+    Args:
+        manifestation_id: The ID of the manifestation to process
+    """
+    def _make_request():
+        url = "https://sqs-search-segmenter-api.onrender.com/jobs/create"
+        payload = {"manifestation_id": manifestation_id}
+        response = requests.post(url, json=payload, timeout=10)
+        logger.info(
+            "Search segmenter API called for manifestation %s. Status: %s",
+            manifestation_id,
+            response.status_code
+        )
+    
+    # Start the request in a background thread
+    thread = threading.Thread(target=_make_request, daemon=True)
+    thread.start()
 
 
 @instances_bp.route("/<string:manifestation_id>", methods=["GET"], strict_slashes=False)
@@ -327,6 +351,9 @@ def _create_aligned_text(
         logger.error("Error creating aligned text: %s", e)
         MockStorage().rollback_base_text(expression_id=expression_id, manifestation_id=manifestation_id)
         raise e
+
+    # Trigger search segmenter API asynchronously
+    _trigger_search_segmenter(manifestation_id)
 
     return (
         jsonify(

--- a/functions/api/texts.py
+++ b/functions/api/texts.py
@@ -3,6 +3,7 @@ import logging
 from exceptions import InvalidRequest, DataNotFound
 from flask import Blueprint, Response, jsonify, request
 from identifier import generate_id
+from api.instances import _trigger_search_segmenter
 from models import (
     AnnotationModel, 
     AnnotationType, 
@@ -180,6 +181,9 @@ def create_instance(expression_id: str) -> tuple[Response, int]:
         bibliography_annotation=bibliography_annotation,
         bibliography_segments=bibliography_segments,
     )
+
+    # Trigger search segmenter API asynchronously
+    _trigger_search_segmenter(manifestation_id)
 
     return jsonify({"message": "Instance created successfully", "id": manifestation_id}), 201
 


### PR DESCRIPTION
- Added a new function to trigger the search segmenter API asynchronously using threading.
- Integrated the asynchronous call in both the `create_instance` and `_create_aligned_text` functions to enhance performance without blocking the main thread.