### PR TITLE
refactor: improve Neo4j query for license association

### DIFF
--- a/functions/neo4j_queries.py
+++ b/functions/neo4j_queries.py
@@ -333,7 +333,8 @@ MATCH (e:Expression {id: $expression_id})
 OPTIONAL MATCH (e)-[lc_rel:HAS_LICENSE]->(license:License)
 WITH e, lc_rel
 DELETE lc_rel
-MERGE (e)-[:HAS_LICENSE]->(:License {name: $license})
+MATCH (license:License {name: $license})
+MERGE (e)-[:HAS_LICENSE]->(license)
 RETURN e.id as expression_id
 """,
 }


### PR DESCRIPTION
- Changed the license association logic to first MATCH the existing license before MERGE, ensuring that the relationship is created only if the license already exists. This enhances query efficiency and prevents unnecessary license creation.