### PR TITLE
fix: update endpoint and variable names for base text updates

### DIFF
--- a/functions/api/instances.py
+++ b/functions/api/instances.py
@@ -632,8 +632,8 @@ def _calculate_base_text_diffs(old_segments: list[dict], new_segments: list) -> 
     return diffs
 
 
-@instances_bp.route("/<string:manifestation_id>/base-text", methods=["PUT"], strict_slashes=False)
-def update_base_text(manifestation_id: str) -> tuple[Response, int]:
+@instances_bp.route("/<string:instance_id>/base-text", methods=["PUT"], strict_slashes=False)
+def update_base_text(instance_id: str) -> tuple[Response, int]:
     """
     Update base text content and segmentation spans.
 
@@ -654,9 +654,9 @@ def update_base_text(manifestation_id: str) -> tuple[Response, int]:
     db = Neo4JDatabase()
     storage = Storage()
 
-    old_segments = db.get_segmentation_annotation_by_manifestation(manifestation_id=manifestation_id)
+    old_segments = db.get_segmentation_annotation_by_manifestation(manifestation_id=instance_id)
     if not old_segments:
-        return jsonify({"error": f"No segmentation segments found for manifestation '{manifestation_id}'"}), 404
+        return jsonify({"error": f"No segmentation segments found for manifestation '{instance_id}'"}), 404
 
     diffs = _calculate_base_text_diffs(old_segments=old_segments, new_segments=request_model.segmentation)
 
@@ -666,17 +666,17 @@ def update_base_text(manifestation_id: str) -> tuple[Response, int]:
     ]
     db.update_segmentation_spans(segments_payload)
 
-    expression_id = db.get_expression_id_by_manifestation_id(manifestation_id=manifestation_id)
+    expression_id = db.get_expression_id_by_manifestation_id(manifestation_id=instance_id)
     if not expression_id:
-        raise DataNotFound(f"Expression for manifestation '{manifestation_id}' not found")
+        raise DataNotFound(f"Expression for manifestation '{instance_id}' not found")
 
-    storage.store_base_text(expression_id=expression_id, manifestation_id=manifestation_id, base_text=request_model.content)
+    storage.store_base_text(expression_id=expression_id, manifestation_id=instance_id, base_text=request_model.content)
 
     return (
         jsonify(
             {
                 "message": "Base text updated successfully",
-                "manifestation_id": manifestation_id,
+                "manifestation_id": instance_id,
                 "diffs": diffs,
             }
         ),

--- a/functions/api/schema/openapi.yaml
+++ b/functions/api/schema/openapi.yaml
@@ -354,6 +354,122 @@ paths:
           $ref: '#/components/responses/NotFound'
         "500":
           $ref: '#/components/responses/ServerError'
+  /v2/instances/{instance_id}/base-text:
+    put:
+      summary: Update base text content and segmentation spans
+      description: >-
+        Update base text content for an instance and update its segmentation spans (segment IDs must be preserved).
+        The API also returns diffs computed between old and new segmentation spans as a list of (segment_id, coordinate, delta).
+      tags:
+        - Instances
+      parameters:
+        - name: instance_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The ID of the instance (manifestation) to update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - content
+                - segmentation
+              properties:
+                content:
+                  type: string
+                  description: The full updated base text content
+                segmentation:
+                  type: array
+                  description: List of segments with their updated spans in the new base text (same segment IDs)
+                  items:
+                    type: object
+                    required:
+                      - id
+                      - span
+                    properties:
+                      id:
+                        type: string
+                        description: Segment ID (must match an existing segmentation segment for this instance)
+                      span:
+                        type: object
+                        required:
+                          - start
+                          - end
+                        properties:
+                          start:
+                            type: integer
+                            minimum: 0
+                            description: Start character position (inclusive)
+                          end:
+                            type: integer
+                            minimum: 1
+                            description: End character position (exclusive)
+            examples:
+              update_base_text_request:
+                summary: Update base text with new segmentation spans
+                value:
+                  content: "Updated base text content..."
+                  segmentation:
+                    - id: "SEG001"
+                      span:
+                        start: 0
+                        end: 12
+                    - id: "SEG002"
+                      span:
+                        start: 12
+                        end: 25
+      responses:
+        "200":
+          description: Base text updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    examples:
+                      - "Base text updated successfully"
+                  manifestation_id:
+                    type: string
+                    description: The ID of the updated manifestation (same as instance_id)
+                  diffs:
+                    type: array
+                    description: List of diffs computed from old vs new segmentation spans
+                    items:
+                      type: object
+                      properties:
+                        segment_id:
+                          type: string
+                          description: Segment ID for which the span length changed
+                        coordinate:
+                          type: integer
+                          description: Edit coordinate in the old text adjusted by cumulative previous deltas
+                        delta:
+                          type: integer
+                          description: Change in segment length (new_len - old_len)
+              examples:
+                update_base_text_response:
+                  summary: Successful base text update
+                  value:
+                    message: "Base text updated successfully"
+                    manifestation_id: "I12345678"
+                    diffs:
+                      - segment_id: "SEG001"
+                        coordinate: 12
+                        delta: 3
+        "400":
+          $ref: '#/components/responses/InvalidRequest'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "422":
+          $ref: '#/components/responses/ValidationError'
+        "500":
+          $ref: '#/components/responses/ServerError'
   /v2/instances/{instance_id}/related:
     get:
       summary: Find related instances


### PR DESCRIPTION
- Changed the route parameter from 'manifestation_id' to 'instance_id' for clarity and consistency.
- Updated all references in the update_base_text function to use 'instance_id' instead of 'manifestation_id'.
- Enhanced OpenAPI documentation to reflect the updated endpoint and request structure for base text updates.