### PR TITLE
feat: add functionality to update alternative titles for expressions

### DIFF
--- a/functions/api/schema/openapi.yaml
+++ b/functions/api/schema/openapi.yaml
@@ -2222,29 +2222,28 @@ paths:
         "500":
           $ref: '#/components/responses/ServerError'
 
-  /v2/texts/{texts_id}/title:
+  /v2/texts/{text_id}/title:
     put:
       summary: Update texts title
       description: >-
-        Update the title of a texts. The title should be provided as a dictionary
-        with language code as the key and the title text as the value.
+        Update the title or alternative title of a text. The title or alt_title
+        should be provided as a dictionary with language code as the key and the
+        title text as the value.
       tags:
         - Texts
       parameters:
-        - name: texts_id
+        - name: text_id
           in: path
           required: true
           schema:
             type: string
-          description: The texts ID of the text to update
+          description: The text ID of the text to update
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              required:
-                - title
               properties:
                 title:
                   type: object
@@ -2253,6 +2252,16 @@ paths:
                     type: string
                   example:
                     bo: "རྒྱལ་པོ་རབས་ཀྱི་གཏམ་རྒྱུད།"
+                alt_title:
+                  type: object
+                  description: Dictionary with language code as key and alternative title text as value
+                  additionalProperties:
+                    type: string
+                  example:
+                    bo: "མཚན་བྱང་གཞན།"
+              anyOf:
+                - required: [title]
+                - required: [alt_title]
       responses:
         "200":
           description: Title updated successfully
@@ -2273,7 +2282,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: "Title is required"
+                    example: "Title or alt_title is required"
         "404":
           $ref: '#/components/responses/NotFound'
         "500":

--- a/functions/neo4j_database.py
+++ b/functions/neo4j_database.py
@@ -1774,6 +1774,20 @@ class Neo4JDatabase:
             if result is None:
                 raise DataNotFound(f"Expression with ID '{expression_id}' not found")
 
+    def update_alt_title(self, expression_id: str, alt_title: dict[str, str]) -> None:
+        logger.info("Updating alt title for expression ID: %s", expression_id)
+        with self.get_session() as session:
+            result = session.execute_write(
+                lambda tx: tx.run(
+                    Queries.expressions["update_alt_title"],
+                    expression_id=expression_id,
+                    alt_title=alt_title,
+                ).single()
+            )
+
+            if result is None:
+                raise DataNotFound(f"Expression with ID '{expression_id}' not found")
+
     def update_license(self, expression_id: str, license: LicenseType) -> None:
         with self.get_session() as session:
             result = session.execute_write(

--- a/functions/neo4j_queries.py
+++ b/functions/neo4j_queries.py
@@ -328,6 +328,20 @@ FOREACH (_ IN CASE WHEN existing_lt IS NULL THEN [1] ELSE [] END |
 )
 RETURN e.id as expression_id
 """,
+    "update_alt_title": """
+MATCH (e:Expression {id: $expression_id})-[:HAS_TITLE]->(primary_nomen:Nomen)
+MATCH (l:Language {code: $alt_title.lang_code})
+OPTIONAL MATCH (primary_nomen)<-[:ALTERNATIVE_OF]-(alt_nomen:Nomen)
+    -[:HAS_LOCALIZATION]->(existing_lt:LocalizedText)-[:HAS_LANGUAGE]->(l)
+FOREACH (_ IN CASE WHEN existing_lt IS NOT NULL THEN [1] ELSE [] END |
+    SET existing_lt.text = $alt_title.text
+)
+FOREACH (_ IN CASE WHEN existing_lt IS NULL THEN [1] ELSE [] END |
+    CREATE (new_alt:Nomen)-[:ALTERNATIVE_OF]->(primary_nomen)
+    CREATE (new_alt)-[:HAS_LOCALIZATION]->(new_lt:LocalizedText {text: $alt_title.text})-[:HAS_LANGUAGE]->(l)
+)
+RETURN e.id as expression_id
+""",
     "update_license": """
 MATCH (e:Expression {id: $expression_id})
 OPTIONAL MATCH (e)-[lc_rel:HAS_LICENSE]->(license:License)


### PR DESCRIPTION
- Implemented a new method `update_alt_title` in the `Neo4JDatabase` class to handle updates for alternative titles in the database.
- Updated the Neo4j query to support the creation and updating of alternative titles based on language codes.
- Enhanced the API endpoint to accept both title and alternative title in the request body, ensuring validation for language codes.
- Added comprehensive unit tests to verify the correct behavior of updating alternative titles, including scenarios for adding new languages and overwriting existing ones.