### PR TITLE
feat: enhance alt_title handling in update_title API

### DIFF
--- a/functions/api/texts.py
+++ b/functions/api/texts.py
@@ -214,7 +214,18 @@ def update_title(expression_id: str) -> tuple[Response, int]:
 
     title = data.get("title")
     alt_title = data.get("alt_title")
-    if not title and not alt_title:
+
+    # Normalize alt_title to a list of dicts
+    alt_title_entries: list[dict[str, str]] = []
+    if alt_title is not None:
+        if isinstance(alt_title, list):
+            alt_title_entries = alt_title
+        elif isinstance(alt_title, dict):
+            alt_title_entries = [alt_title]
+        else:
+            return jsonify({"error": "alt_title must be an object or list of objects"}), 400
+
+    if not title and not alt_title_entries:
         return jsonify({"error": "Title or alt_title is required"}), 400
 
     db = Neo4JDatabase()
@@ -229,11 +240,13 @@ def update_title(expression_id: str) -> tuple[Response, int]:
             # Validate that the language code exists
             Neo4JDatabaseValidator().validate_language_code_exists(session, base_lang_code)
 
-        if alt_title:
-            alt_lang_code = list(alt_title.keys())[0]
-            base_alt_lang_code = alt_lang_code.split("-")[0].lower()
-
-            Neo4JDatabaseValidator().validate_language_code_exists(session, base_alt_lang_code)
+        # Validate all alt_title entries
+        for alt_entry in alt_title_entries:
+            if not isinstance(alt_entry, dict) or not alt_entry:
+                return jsonify({"error": "alt_title entries must be non-empty objects"}), 400
+            for alt_lang_code in alt_entry.keys():
+                base_alt_lang_code = alt_lang_code.split("-")[0].lower()
+                Neo4JDatabaseValidator().validate_language_code_exists(session, base_alt_lang_code)
 
     if title:
         title_data = {
@@ -242,12 +255,14 @@ def update_title(expression_id: str) -> tuple[Response, int]:
         }
         db.update_title(expression_id=expression_id, title=title_data)
 
-    if alt_title:
-        alt_title_data = {
-            "lang_code": alt_lang_code,
-            "text": alt_title[alt_lang_code],
-        }
-        db.update_alt_title(expression_id=expression_id, alt_title=alt_title_data)
+    # Process all alt_title entries
+    for alt_entry in alt_title_entries:
+        for alt_lang_code, alt_text in alt_entry.items():
+            alt_title_data = {
+                "lang_code": alt_lang_code,
+                "text": alt_text,
+            }
+            db.update_alt_title(expression_id=expression_id, alt_title=alt_title_data)
 
     return jsonify({"message": "Title updated successfully"}), 200
 

--- a/functions/neo4j_queries.py
+++ b/functions/neo4j_queries.py
@@ -332,10 +332,7 @@ RETURN e.id as expression_id
 MATCH (e:Expression {id: $expression_id})-[:HAS_TITLE]->(primary_nomen:Nomen)
 MATCH (l:Language {code: $alt_title.lang_code})
 OPTIONAL MATCH (primary_nomen)<-[:ALTERNATIVE_OF]-(alt_nomen:Nomen)
-    -[:HAS_LOCALIZATION]->(existing_lt:LocalizedText)-[:HAS_LANGUAGE]->(l)
-FOREACH (_ IN CASE WHEN existing_lt IS NOT NULL THEN [1] ELSE [] END |
-    SET existing_lt.text = $alt_title.text
-)
+    -[:HAS_LOCALIZATION]->(existing_lt:LocalizedText {text: $alt_title.text})-[:HAS_LANGUAGE]->(l)
 FOREACH (_ IN CASE WHEN existing_lt IS NULL THEN [1] ELSE [] END |
     CREATE (new_alt:Nomen)-[:ALTERNATIVE_OF]->(primary_nomen)
     CREATE (new_alt)-[:HAS_LOCALIZATION]->(new_lt:LocalizedText {text: $alt_title.text})-[:HAS_LANGUAGE]->(l)


### PR DESCRIPTION
- Modified the `update_title` function to accept alt_title as a list of dictionaries, allowing multiple alternative titles for the same language.
- Updated validation to ensure alt_title entries are non-empty objects and language codes are valid.
- Adjusted the Neo4j query to create or update alternative titles accordingly.
- Refactored unit tests to verify the new behavior of adding multiple alt_titles without overwriting existing ones.