### PR TITLE
feat: add author filtering to text retrieval API

### DIFF
--- a/functions/neo4j_database.py
+++ b/functions/neo4j_database.py
@@ -1000,6 +1000,7 @@ class Neo4JDatabase:
             "limit": limit,
             "type": filters.get("type"),
             "language": filters.get("language"),
+            "author": filters.get("author"),
             "title": filters.get("title"),
         }
 

--- a/functions/neo4j_queries.py
+++ b/functions/neo4j_queries.py
@@ -182,6 +182,22 @@ Queries.expressions = {
             WHERE toLower(lt.text) CONTAINS toLower($title)
         }}
     ))
+    AND ($author IS NULL OR (
+        EXISTS {{
+            MATCH (e)-[:HAS_CONTRIBUTION]->(contrib:Contribution)-[:WITH_ROLE]->(role:RoleType)
+            WHERE role.name = 'author'
+            MATCH (contrib)-[:BY]->(person:Person)-[:HAS_NAME]->(nameNomen:Nomen)
+                  -[:HAS_LOCALIZATION]->(nameText:LocalizedText)
+            WHERE toLower(nameText.text) CONTAINS toLower($author)
+        }}
+        OR EXISTS {{
+            MATCH (e)-[:HAS_CONTRIBUTION]->(contrib:Contribution)-[:WITH_ROLE]->(role:RoleType)
+            WHERE role.name = 'author'
+            MATCH (contrib)-[:BY]->(person:Person)-[:HAS_NAME]->(:Nomen)<-[:ALTERNATIVE_OF]-(altName:Nomen)
+                  -[:HAS_LOCALIZATION]->(altNameText:LocalizedText)
+            WHERE toLower(altNameText.text) CONTAINS toLower($author)
+        }}
+    ))
 
     OFFSET $offset
     LIMIT $limit


### PR DESCRIPTION
- Enhanced the Neo4JDatabase and Neo4JQueries to support filtering texts by author name.
- Updated the API to accept an 'author' query parameter, allowing users to retrieve texts associated with specific authors.
- Added unit tests to verify the correct functionality of author filtering, ensuring accurate responses for various author queries.