### PR TITLE
feat: add clear_all_alt_titles method and update alt_titles handling

### DIFF
--- a/functions/api/texts.py
+++ b/functions/api/texts.py
@@ -311,7 +311,7 @@ def update_text(expression_id: str) -> tuple[Response, int]:
     - wiki: Wikipedia/Wikidata identifier
     - date: Date information
     - title: Primary title (localized string)
-    - alt_titles: Alternative titles (list of localized strings)
+    - alt_titles: Alternative titles (list of localized strings, replaces existing)
     - copyright: Copyright status
     - license: License type
     - contributions: List of contributions (replaces existing)

--- a/functions/neo4j_database.py
+++ b/functions/neo4j_database.py
@@ -1904,6 +1904,16 @@ class Neo4JDatabase:
                 ).consume()
             )
 
+    def clear_all_alt_titles(self, expression_id: str) -> None:
+        """Clear all alternative titles from an expression."""
+        with self.get_session() as session:
+            session.execute_write(
+                lambda tx: tx.run(
+                    Queries.expressions["clear_all_alt_titles"],
+                    expression_id=expression_id
+                ).consume()
+            )
+
     def update_expression(self, expression_id: str, update_data: dict) -> None:
         """
         Update an expression with the provided data.
@@ -1937,8 +1947,11 @@ class Neo4JDatabase:
             for lang_code, text in title_dict.items():
                 self.update_title(expression_id, {"lang_code": lang_code, "text": text})
         
-        # Update alt_titles
+        # Update alt_titles (replace all)
         if "alt_titles" in update_data and update_data["alt_titles"] is not None:
+            # Clear existing alt_titles
+            self.clear_all_alt_titles(expression_id)
+            # Add new alt_titles
             for alt_title in update_data["alt_titles"]:
                 for lang_code, text in alt_title.items():
                     self.update_alt_title(expression_id, {"lang_code": lang_code, "text": text})

--- a/functions/neo4j_queries.py
+++ b/functions/neo4j_queries.py
@@ -498,6 +498,12 @@ MATCH (e:Expression {id: $expression_id})-[:HAS_CONTRIBUTION]->(contrib:Contribu
 DETACH DELETE contrib
 RETURN e.id as expression_id
 """,
+    "clear_all_alt_titles": """
+MATCH (e:Expression {id: $expression_id})-[:HAS_TITLE]->(primary_nomen:Nomen)
+OPTIONAL MATCH (primary_nomen)<-[:ALTERNATIVE_OF]-(alt_nomen:Nomen)-[:HAS_LOCALIZATION]->(lt:LocalizedText)
+DETACH DELETE alt_nomen, lt
+RETURN e.id as expression_id
+""",
 }
 
 Queries.persons = {


### PR DESCRIPTION
- Introduced a new method `clear_all_alt_titles` in the Neo4JDatabase to remove all existing alternative titles for an expression before updating.
- Updated the `update_expression` method to call `clear_all_alt_titles` when new alt_titles are provided, ensuring that existing titles are replaced rather than appended.
- Modified the OpenAPI documentation to clarify that alt_titles will replace existing titles during updates.
- Added a test case to verify that updating alt_titles correctly replaces old titles with new ones.